### PR TITLE
Also blacklist org.apache.xalan.xsltc.trax.TemplatesImpl, this comes from https://github.com/FasterXML/jackson-databind/commit/3bfbb835e530055c1941ddf87fde0b08d08dcd38 

### DIFF
--- a/src/mapper/java/org/codehaus/jackson/map/deser/BeanDeserializerFactory.java
+++ b/src/mapper/java/org/codehaus/jackson/map/deser/BeanDeserializerFactory.java
@@ -52,6 +52,7 @@ public class BeanDeserializerFactory
         s.add("org.codehaus.groovy.runtime.MethodClosure");
         s.add("org.springframework.beans.factory.ObjectFactory");
         s.add("com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl");
+        s.add("org.apache.xalan.xsltc.trax.TemplatesImpl");
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 


### PR DESCRIPTION


Signed-off-by: David Black <dblack@atlassian.com>