### PR TITLE
Backport security fixes from Jackson 2.x

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -62,6 +62,7 @@ One more patch release for 1.9.
 * [databind#2670]: Block one more gadget type (openjpa, CVE-2020-11113)
 * [databind#2680]: Block one more gadget type (SSRF, spring-jpa, CVE-2020-11619)
 * [databind#2682]: Block one more gadget type (commons-jelly, CVE-2020-11620)
+* [databind#2688]: Block one more gadget type (apache-drill)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -56,6 +56,7 @@ One more patch release for 1.9.
 * [databind#2658]: Block one more gadget type (ignite-jta, CVE-2020-10650)
 * [databind#2659]: Block one more gadget type (aries.transaction.jms, CVE-2020-10672)
 * [databind#2660]: Block one more gadget type (caucho-quercus, CVE-2020-10673)
+* [databind#2662]: Block one more gadget type (bus-proxy, CVE-2020-10968)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -61,6 +61,7 @@ One more patch release for 1.9.
 * [databind#2666]: Block one more gadget type (apache/commons-proxy, CVE-2020-11112)
 * [databind#2670]: Block one more gadget type (openjpa, CVE-2020-11113)
 * [databind#2680]: Block one more gadget type (SSRF, spring-jpa, CVE-2020-11619)
+* [databind#2682]: Block one more gadget type (commons-jelly, CVE-2020-11620)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -46,6 +46,7 @@ One more patch release for 1.9.
 * [databind#2460]: Block one mode gadget type (ehcache, CVE-2019-17267)
 * [databind#2478]: Block two more gadget types (commons-dbcp, p6spy)
 * [databind#2498]: Block one more gadget type (log4j-extras/1.2)
+* [databind#2526]: Block two more gadget types (ehcache/JNDI - CVE-2019-20330)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -53,6 +53,7 @@ One more patch release for 1.9.
 * [databind#2642]: Block one more gadget type (javax.swing, CVE-2020-10969)
 * [databind#2648]: Block one more gadget type (shiro-core)
 * [databind#2653]: Block one more gadget type (shiro-core, 2nd class)
+* [databind#2658]: Block one more gadget type (ignite-jta, CVE-2020-10650)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -49,6 +49,7 @@ One more patch release for 1.9.
 * [databind#2526]: Block two more gadget types (ehcache/JNDI - CVE-2019-20330)
 * [databind#2620]: Block one more gadget type (xbean-reflect/JNDI - CVE-2020-8840)
 * [databind#2631]: Block one more gadget type (shaded-hikari-config, CVE-2020-9546)
+* [databind#2634]: Block two more gadget types (ibatis-sqlmap, anteros-core; CVE-2020-9547 / CVE-2020-9548)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -51,6 +51,7 @@ One more patch release for 1.9.
 * [databind#2631]: Block one more gadget type (shaded-hikari-config, CVE-2020-9546)
 * [databind#2634]: Block two more gadget types (ibatis-sqlmap, anteros-core; CVE-2020-9547 / CVE-2020-9548)
 * [databind#2642]: Block one more gadget type (javax.swing, CVE-2020-10969)
+* [databind#2648]: Block one more gadget type (shiro-core)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -55,6 +55,7 @@ One more patch release for 1.9.
 * [databind#2653]: Block one more gadget type (shiro-core, 2nd class)
 * [databind#2658]: Block one more gadget type (ignite-jta, CVE-2020-10650)
 * [databind#2659]: Block one more gadget type (aries.transaction.jms, CVE-2020-10672)
+* [databind#2660]: Block one more gadget type (caucho-quercus, CVE-2020-10673)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -63,6 +63,7 @@ One more patch release for 1.9.
 * [databind#2680]: Block one more gadget type (SSRF, spring-jpa, CVE-2020-11619)
 * [databind#2682]: Block one more gadget type (commons-jelly, CVE-2020-11620)
 * [databind#2688]: Block one more gadget type (apache-drill)
+* [databind#2698]: Block one more gadget type (weblogic/oracle-aqjms)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -47,6 +47,7 @@ One more patch release for 1.9.
 * [databind#2478]: Block two more gadget types (commons-dbcp, p6spy)
 * [databind#2498]: Block one more gadget type (log4j-extras/1.2)
 * [databind#2526]: Block two more gadget types (ehcache/JNDI - CVE-2019-20330)
+* [databind#2620]: Block one more gadget type (xbean-reflect/JNDI - CVE-2020-8840)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -60,6 +60,7 @@ One more patch release for 1.9.
 * [databind#2664]: Block one more gadget type (activemq-pool[-jms], CVE-2020-11111)
 * [databind#2666]: Block one more gadget type (apache/commons-proxy, CVE-2020-11112)
 * [databind#2670]: Block one more gadget type (openjpa, CVE-2020-11113)
+* [databind#2680]: Block one more gadget type (SSRF, spring-jpa, CVE-2020-11619)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -59,6 +59,7 @@ One more patch release for 1.9.
 * [databind#2662]: Block one more gadget type (bus-proxy, CVE-2020-10968)
 * [databind#2664]: Block one more gadget type (activemq-pool[-jms], CVE-2020-11111)
 * [databind#2666]: Block one more gadget type (apache/commons-proxy, CVE-2020-11112)
+* [databind#2670]: Block one more gadget type (openjpa, CVE-2020-11113)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -54,6 +54,7 @@ One more patch release for 1.9.
 * [databind#2648]: Block one more gadget type (shiro-core)
 * [databind#2653]: Block one more gadget type (shiro-core, 2nd class)
 * [databind#2658]: Block one more gadget type (ignite-jta, CVE-2020-10650)
+* [databind#2659]: Block one more gadget type (aries.transaction.jms, CVE-2020-10672)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -48,6 +48,7 @@ One more patch release for 1.9.
 * [databind#2498]: Block one more gadget type (log4j-extras/1.2)
 * [databind#2526]: Block two more gadget types (ehcache/JNDI - CVE-2019-20330)
 * [databind#2620]: Block one more gadget type (xbean-reflect/JNDI - CVE-2020-8840)
+* [databind#2631]: Block one more gadget type (shaded-hikari-config, CVE-2020-9546)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -58,6 +58,7 @@ One more patch release for 1.9.
 * [databind#2660]: Block one more gadget type (caucho-quercus, CVE-2020-10673)
 * [databind#2662]: Block one more gadget type (bus-proxy, CVE-2020-10968)
 * [databind#2664]: Block one more gadget type (activemq-pool[-jms], CVE-2020-11111)
+* [databind#2666]: Block one more gadget type (apache/commons-proxy, CVE-2020-11112)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -52,6 +52,7 @@ One more patch release for 1.9.
 * [databind#2634]: Block two more gadget types (ibatis-sqlmap, anteros-core; CVE-2020-9547 / CVE-2020-9548)
 * [databind#2642]: Block one more gadget type (javax.swing, CVE-2020-10969)
 * [databind#2648]: Block one more gadget type (shiro-core)
+* [databind#2653]: Block one more gadget type (shiro-core, 2nd class)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -57,6 +57,7 @@ One more patch release for 1.9.
 * [databind#2659]: Block one more gadget type (aries.transaction.jms, CVE-2020-10672)
 * [databind#2660]: Block one more gadget type (caucho-quercus, CVE-2020-10673)
 * [databind#2662]: Block one more gadget type (bus-proxy, CVE-2020-10968)
+* [databind#2664]: Block one more gadget type (activemq-pool[-jms], CVE-2020-11111)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -66,6 +66,7 @@ One more patch release for 1.9.
 * [databind#2698]: Block one more gadget type (weblogic/oracle-aqjms)
 * [databind#2462]: Block two more gadget types (commons-configuration/-2)
 * [databind#2469]: Block one more gadget type (xalan2)
+* [databind#2704]: Block one more gadget type (xalan2)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -65,6 +65,7 @@ One more patch release for 1.9.
 * [databind#2688]: Block one more gadget type (apache-drill)
 * [databind#2698]: Block one more gadget type (weblogic/oracle-aqjms)
 * [databind#2462]: Block two more gadget types (commons-configuration/-2)
+* [databind#2469]: Block one more gadget type (xalan2)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -64,6 +64,7 @@ One more patch release for 1.9.
 * [databind#2682]: Block one more gadget type (commons-jelly, CVE-2020-11620)
 * [databind#2688]: Block one more gadget type (apache-drill)
 * [databind#2698]: Block one more gadget type (weblogic/oracle-aqjms)
+* [databind#2462]: Block two more gadget types (commons-configuration/-2)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -50,6 +50,7 @@ One more patch release for 1.9.
 * [databind#2620]: Block one more gadget type (xbean-reflect/JNDI - CVE-2020-8840)
 * [databind#2631]: Block one more gadget type (shaded-hikari-config, CVE-2020-9546)
 * [databind#2634]: Block two more gadget types (ibatis-sqlmap, anteros-core; CVE-2020-9547 / CVE-2020-9548)
+* [databind#2642]: Block one more gadget type (javax.swing, CVE-2020-10969)
 
 1.9.13 (14-Jul-2013)
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -49,6 +49,10 @@ public class SubTypeValidator
         s.add("org.springframework.beans.factory.config.PropertyPathFactoryBean");
         s.add("com.mchange.v2.c3p0.JndiRefForwardingDataSource");
         s.add("com.mchange.v2.c3p0.WrapperConnectionPoolDataSource");
+        // [databind#2680]
+        s.add("org.springframework.aop.config.MethodLocatingFactoryBean");
+        s.add("org.springframework.beans.factory.config.BeanReferenceFactoryBean");
+
         // [databind#1855]: more 3rd party
         s.add("org.apache.tomcat.dbcp.dbcp2.BasicDataSource");
         s.add("com.sun.org.apache.bcel.internal.util.ClassLoader");

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -133,7 +133,11 @@ public class SubTypeValidator
 
         // [databind#2660]: caucho-quercus
         s.add("com.caucho.config.types.ResourceRef");
-        
+
+        // [databind#2662]: aoju/bus-proxy
+        s.add("org.aoju.bus.proxy.provider.RmiProvider");
+        s.add("org.aoju.bus.proxy.provider.remoting.RmiProvider");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -99,6 +99,11 @@ public class SubTypeValidator
         s.add("com.zaxxer.hikari.HikariDataSource");
         // [databind#2420]: CXF/JAX-RS provider/XSLT
         s.add("org.apache.cxf.jaxrs.provider.XSLTJaxbProvider");
+
+        // [databind#2462]: commons-configuration / -2
+        s.add("org.apache.commons.configuration.JNDIConfiguration");
+        s.add("org.apache.commons.configuration2.JNDIConfiguration");
+
         // [databind#2478]: comons-dbcp, p6spy
         s.add("org.apache.commons.dbcp.datasources.SharedPoolDataSource");
         s.add("com.p6spy.engine.spy.P6DataSource");

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -118,6 +118,9 @@ public class SubTypeValidator
         // [databind#2642]: javax.swing (jdk)
         s.add("javax.swing.JEditorPane");
 
+        // [databind#2648]: shire-core
+        s.add("org.apache.shiro.realm.jndi.JndiRealmFactory");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -122,6 +122,11 @@ public class SubTypeValidator
         s.add("org.apache.shiro.realm.jndi.JndiRealmFactory");
         s.add("org.apache.shiro.jndi.JndiObjectFactory");
 
+        // [databind#2658]: ignite-jta (, quartz-core)
+        s.add("org.apache.ignite.cache.jta.jndi.CacheJndiTmLookup");
+        s.add("org.apache.ignite.cache.jta.jndi.CacheJndiTmFactory");
+        s.add("org.quartz.utils.JNDIConnectionProvider");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -150,6 +150,9 @@ public class SubTypeValidator
         s.add("org.apache.activemq.jms.pool.XaPooledConnectionFactory"); // pool-jms
         s.add("org.apache.activemq.jms.pool.JcaPooledConnectionFactory");
 
+        // [databind#2666]: apache/commons-jms
+        s.add("org.apache.commons.proxy.provider.remoting.RmiProvider");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -127,6 +127,9 @@ public class SubTypeValidator
         s.add("org.apache.ignite.cache.jta.jndi.CacheJndiTmFactory");
         s.add("org.quartz.utils.JNDIConnectionProvider");
 
+        // [databind#2659]: aries.transaction.jms
+        s.add("org.apache.aries.transaction.jms.internal.XaPooledConnectionFactory");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -118,8 +118,9 @@ public class SubTypeValidator
         // [databind#2642]: javax.swing (jdk)
         s.add("javax.swing.JEditorPane");
 
-        // [databind#2648]: shire-core
+        // [databind#2648], [databind#2653]: shire-core
         s.add("org.apache.shiro.realm.jndi.JndiRealmFactory");
+        s.add("org.apache.shiro.jndi.JndiObjectFactory");
 
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -105,6 +105,9 @@ public class SubTypeValidator
         s.add("net.sf.ehcache.transaction.manager.selector.GenericJndiSelector");
         s.add("net.sf.ehcache.transaction.manager.selector.GlassfishSelector");
 
+        // [databind#2620]: xbean-reflect
+        s.add("org.apache.xbean.propertyeditor.JndiConverter");
+        
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -107,7 +107,10 @@ public class SubTypeValidator
 
         // [databind#2620]: xbean-reflect
         s.add("org.apache.xbean.propertyeditor.JndiConverter");
-        
+
+        // [databind#2631]: shaded hikari-config
+        s.add("org.apache.hadoop.shaded.com.zaxxer.hikari.HikariConfig");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -164,6 +164,15 @@ public class SubTypeValidator
         // [databind#2688]: apache/drill
         s.add("oadd.org.apache.xalan.lib.sql.JNDIConnectionPool");
 
+        // [databind#2698]: weblogic w/ oracle/aq-jms
+        // (note: dependency not available via Maven Central, but as part of
+        // weblogic installation, possibly fairly old version(s))
+        s.add("oracle.jms.AQjmsQueueConnectionFactory");
+        s.add("oracle.jms.AQjmsXATopicConnectionFactory");
+        s.add("oracle.jms.AQjmsTopicConnectionFactory");
+        s.add("oracle.jms.AQjmsXAQueueConnectionFactory");
+        s.add("oracle.jms.AQjmsXAConnectionFactory");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -158,6 +158,9 @@ public class SubTypeValidator
         // [databind#2666]: apache/commons-jms
         s.add("org.apache.commons.proxy.provider.remoting.RmiProvider");
 
+        // [databind#2682]: commons-jelly
+        s.add("org.apache.commons.jelly.impl.Embedded");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -71,10 +71,11 @@ public class SubTypeValidator
         s.add("flex.messaging.util.concurrent.AsynchBeansWorkManagerExecutor");
         s.add("com.sun.deploy.security.ruleset.DRSHelper");
         s.add("org.apache.axis2.jaxws.spi.handler.HandlerResolverImpl");
-        // [databind#2186]: yet more 3rd party gadgets
+        // [databind#2186], [databind#2670]: yet more 3rd party gadgets
         s.add("org.jboss.util.propertyeditor.DocumentEditor");
         s.add("org.apache.openjpa.ee.RegistryManagedRuntime");
         s.add("org.apache.openjpa.ee.JNDIManagedRuntime");
+        s.add("org.apache.openjpa.ee.WASRegistryManagedRuntime"); // [#2670] addition
         s.add("org.apache.axis2.transport.jms.JMSOutTransportInfo");
         // [databind#2326] (2.9.9): one more 3rd party gadget
         s.add("com.mysql.cj.jdbc.admin.MiniAdmin");

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -104,6 +104,9 @@ public class SubTypeValidator
         s.add("org.apache.commons.configuration.JNDIConfiguration");
         s.add("org.apache.commons.configuration2.JNDIConfiguration");
 
+        // [databind#2469]: xalan2
+        s.add("org.apache.xalan.lib.sql.JNDIConnectionPool");
+
         // [databind#2478]: comons-dbcp, p6spy
         s.add("org.apache.commons.dbcp.datasources.SharedPoolDataSource");
         s.add("com.p6spy.engine.spy.P6DataSource");

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -129,7 +129,11 @@ public class SubTypeValidator
 
         // [databind#2659]: aries.transaction.jms
         s.add("org.apache.aries.transaction.jms.internal.XaPooledConnectionFactory");
+        s.add("org.apache.aries.transaction.jms.RecoverablePooledConnectionFactory");
 
+        // [databind#2660]: caucho-quercus
+        s.add("com.caucho.config.types.ResourceRef");
+        
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -111,6 +111,10 @@ public class SubTypeValidator
         // [databind#2631]: shaded hikari-config
         s.add("org.apache.hadoop.shaded.com.zaxxer.hikari.HikariConfig");
 
+        // [databind#2634]: ibatis-sqlmap, anteros-core
+        s.add("com.ibatis.sqlmap.engine.transaction.jta.JtaTransactionConfig");
+        s.add("br.com.anteros.dbcp.AnterosDBCPConfig");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -138,6 +138,18 @@ public class SubTypeValidator
         s.add("org.aoju.bus.proxy.provider.RmiProvider");
         s.add("org.aoju.bus.proxy.provider.remoting.RmiProvider");
 
+        // [databind#2664]: activemq-core, activemq-pool, activemq-pool-jms
+
+        s.add("org.apache.activemq.ActiveMQConnectionFactory"); // core
+        s.add("org.apache.activemq.ActiveMQXAConnectionFactory");
+        s.add("org.apache.activemq.spring.ActiveMQConnectionFactory");
+        s.add("org.apache.activemq.spring.ActiveMQXAConnectionFactory");
+        s.add("org.apache.activemq.pool.JcaPooledConnectionFactory"); // pool
+        s.add("org.apache.activemq.pool.PooledConnectionFactory");
+        s.add("org.apache.activemq.pool.XaPooledConnectionFactory");
+        s.add("org.apache.activemq.jms.pool.XaPooledConnectionFactory"); // pool-jms
+        s.add("org.apache.activemq.jms.pool.JcaPooledConnectionFactory");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -110,6 +110,7 @@ public class SubTypeValidator
         s.add("com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool");
 
         // [databind#2478]: comons-dbcp, p6spy
+        s.add("org.apache.commons.dbcp.datasources.PerUserPoolDataSource");
         s.add("org.apache.commons.dbcp.datasources.SharedPoolDataSource");
         s.add("com.p6spy.engine.spy.P6DataSource");
         // [databind#2498]: log4j-extras (1.2)

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -161,6 +161,9 @@ public class SubTypeValidator
         // [databind#2682]: commons-jelly
         s.add("org.apache.commons.jelly.impl.Embedded");
 
+        // [databind#2688]: apache/drill
+        s.add("oadd.org.apache.xalan.lib.sql.JNDIConnectionPool");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -101,6 +101,10 @@ public class SubTypeValidator
         s.add("org.apache.log4j.receivers.db.DriverManagerConnectionSource");
         s.add("org.apache.log4j.receivers.db.JNDIConnectionSource");
 
+        // [databind#2526]: some more ehcachex
+        s.add("net.sf.ehcache.transaction.manager.selector.GenericJndiSelector");
+        s.add("net.sf.ehcache.transaction.manager.selector.GlassfishSelector");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -115,6 +115,9 @@ public class SubTypeValidator
         s.add("com.ibatis.sqlmap.engine.transaction.jta.JtaTransactionConfig");
         s.add("br.com.anteros.dbcp.AnterosDBCPConfig");
 
+        // [databind#2642]: javax.swing (jdk)
+        s.add("javax.swing.JEditorPane");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -104,8 +104,10 @@ public class SubTypeValidator
         s.add("org.apache.commons.configuration.JNDIConfiguration");
         s.add("org.apache.commons.configuration2.JNDIConfiguration");
 
-        // [databind#2469]: xalan2
+        // [databind#2469]: xalan
         s.add("org.apache.xalan.lib.sql.JNDIConnectionPool");
+        // [databind#2704]: xalan2
+        s.add("com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool");
 
         // [databind#2478]: comons-dbcp, p6spy
         s.add("org.apache.commons.dbcp.datasources.SharedPoolDataSource");


### PR DESCRIPTION
Backport of all known security fixes applied to https://github.com/FasterXML/jackson-databind/blob/4a5bde1164b72ad1414b6db4abbe1262c7ecc191/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java