### PR TITLE
Issue/mnstr 5023 backport security fixes

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -62,11 +62,11 @@ One more patch release for 1.9.
 * [databind#2670]: Block one more gadget type (openjpa, CVE-2020-11113)
 * [databind#2680]: Block one more gadget type (SSRF, spring-jpa, CVE-2020-11619)
 * [databind#2682]: Block one more gadget type (commons-jelly, CVE-2020-11620)
-* [databind#2688]: Block one more gadget type (apache-drill)
-* [databind#2698]: Block one more gadget type (weblogic/oracle-aqjms)
-* [databind#2462]: Block two more gadget types (commons-configuration/-2)
-* [databind#2469]: Block one more gadget type (xalan2)
-* [databind#2704]: Block one more gadget type (xalan2)
+* [databind#2688]: Block one more gadget type (apache-drill, CVE-2020-14060)
+* [databind#2698]: Block one more gadget type (weblogic/oracle-aqjms, CVE-2020-14061)
+* [databind#2462]: Block two more gadget types (commons-configuration/-2, CVE-2019-14892)
+* [databind#2469]: Block one more gadget type (xalan2, might be related to CVE-2019-14893)
+* [databind#2704]: Block one more gadget type (xalan2, CVE-2020-14062)
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -79,6 +79,7 @@ One more patch release for 1.9.
 * [databind#2998]: Block 2 more gadget types (org.apache.tomcat/tomcat-dbcp, CVE-2020-36184/CVE-2020-36185)
 * [databind#2999]: Block one more gadget type (org.glassfish.web/javax.servlet.jsp.jstl, CVE-2020-35728)
 * [databind#3003]: Block one more gadget type (org.docx4j.org.apache:xalan-interpretive, CVE-2020-36183)
+* [databind#3004]: Block some more DBCP-related potential gadget classes (CVE-2020-36179, CVE-2020-36180, CVE-2020-36181, CVE-2020-36182)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -67,7 +67,9 @@ One more patch release for 1.9.
 * [databind#2462]: Block two more gadget types (commons-configuration/-2, CVE-2019-14892)
 * [databind#2469]: Block one more gadget type (xalan2, might be related to CVE-2019-14893)
 * [databind#2704]: Block one more gadget type (xalan2, CVE-2020-14062)
-* [databind#2765]: Block one more gadget type (org.jsecurity, 2020-14195)
+* [databind#2765]: Block one more gadget type (org.jsecurity, CVE-2020-14195)
+* [databind#2798]: Block one more gadget type (CVE-2020-24750)
+
 
 1.9.13 (14-Jul-2013)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -78,6 +78,7 @@ One more patch release for 1.9.
 * [databind#2997]: Block 2 more gadget types (tomcat/naming-factory-dbcp, CVE-2020-36186/CVE-2020-36187)
 * [databind#2998]: Block 2 more gadget types (org.apache.tomcat/tomcat-dbcp, CVE-2020-36184/CVE-2020-36185)
 * [databind#2999]: Block one more gadget type (org.glassfish.web/javax.servlet.jsp.jstl, CVE-2020-35728)
+* [databind#3003]: Block one more gadget type (org.docx4j.org.apache:xalan-interpretive, CVE-2020-36183)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -73,6 +73,7 @@ One more patch release for 1.9.
 * [databind#2826]: Block one more gadget type (com.nqadmin.rowset, CVE-xxxx-xxx)
 * [databind#2827]: Block one more gadget type (org.arrahtec:profiler-core, CVE-xxxx-xxx)
 * [databind#2854]: Block one more gadget type (javax.swing, CVE-2021-20190)
+* [databind#2986]: Block 2 more gadget types (commons-dbcp2, CVE-2020-35490/CVE-2020-35491)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -75,6 +75,7 @@ One more patch release for 1.9.
 * [databind#2854]: Block one more gadget type (javax.swing, CVE-2021-20190)
 * [databind#2986]: Block 2 more gadget types (commons-dbcp2, CVE-2020-35490/CVE-2020-35491)
 * [databind#2996]: Block 2 more gadget types (newrelic-agent, CVE-2020-36188/CVE-2020-36189)
+* [databind#2997]: Block 2 more gadget types (tomcat/naming-factory-dbcp, CVE-2020-36186/CVE-2020-36187)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -70,6 +70,8 @@ One more patch release for 1.9.
 * [databind#2765]: Block one more gadget type (org.jsecurity, CVE-2020-14195)
 * [databind#2798]: Block one more gadget type (com.pastdev.httpcomponents, CVE-2020-24750)
 * [databind#2814]: Block one more gadget type (Anteros-DBCP, CVE-2020-24616)
+* [databind#2826]: Block one more gadget type Block one more gadget type (com.nqadmin.rowset, CVE-xxxx-xxx)
+* [databind#2827]: Block one more gadget type Block one more gadget type (org.arrahtec:profiler-core, CVE-xxxx-xxx)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -70,8 +70,9 @@ One more patch release for 1.9.
 * [databind#2765]: Block one more gadget type (org.jsecurity, CVE-2020-14195)
 * [databind#2798]: Block one more gadget type (com.pastdev.httpcomponents, CVE-2020-24750)
 * [databind#2814]: Block one more gadget type (Anteros-DBCP, CVE-2020-24616)
-* [databind#2826]: Block one more gadget type Block one more gadget type (com.nqadmin.rowset, CVE-xxxx-xxx)
-* [databind#2827]: Block one more gadget type Block one more gadget type (org.arrahtec:profiler-core, CVE-xxxx-xxx)
+* [databind#2826]: Block one more gadget type (com.nqadmin.rowset, CVE-xxxx-xxx)
+* [databind#2827]: Block one more gadget type (org.arrahtec:profiler-core, CVE-xxxx-xxx)
+* [databind#2854]: Block one more gadget type (javax.swing, CVE-2021-20190)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -68,7 +68,8 @@ One more patch release for 1.9.
 * [databind#2469]: Block one more gadget type (xalan2, might be related to CVE-2019-14893)
 * [databind#2704]: Block one more gadget type (xalan2, CVE-2020-14062)
 * [databind#2765]: Block one more gadget type (org.jsecurity, CVE-2020-14195)
-* [databind#2798]: Block one more gadget type (CVE-2020-24750)
+* [databind#2798]: Block one more gadget type (com.pastdev.httpcomponents, CVE-2020-24750)
+* [databind#2814]: Block one more gadget type (Anteros-DBCP, CVE-2020-24616)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -76,6 +76,7 @@ One more patch release for 1.9.
 * [databind#2986]: Block 2 more gadget types (commons-dbcp2, CVE-2020-35490/CVE-2020-35491)
 * [databind#2996]: Block 2 more gadget types (newrelic-agent, CVE-2020-36188/CVE-2020-36189)
 * [databind#2997]: Block 2 more gadget types (tomcat/naming-factory-dbcp, CVE-2020-36186/CVE-2020-36187)
+* [databind#2998]: Block 2 more gadget types (org.apache.tomcat/tomcat-dbcp, CVE-2020-36184/CVE-2020-36185)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -77,6 +77,7 @@ One more patch release for 1.9.
 * [databind#2996]: Block 2 more gadget types (newrelic-agent, CVE-2020-36188/CVE-2020-36189)
 * [databind#2997]: Block 2 more gadget types (tomcat/naming-factory-dbcp, CVE-2020-36186/CVE-2020-36187)
 * [databind#2998]: Block 2 more gadget types (org.apache.tomcat/tomcat-dbcp, CVE-2020-36184/CVE-2020-36185)
+* [databind#2999]: Block one more gadget type (org.glassfish.web/javax.servlet.jsp.jstl, CVE-2020-35728)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -74,6 +74,7 @@ One more patch release for 1.9.
 * [databind#2827]: Block one more gadget type (org.arrahtec:profiler-core, CVE-xxxx-xxx)
 * [databind#2854]: Block one more gadget type (javax.swing, CVE-2021-20190)
 * [databind#2986]: Block 2 more gadget types (commons-dbcp2, CVE-2020-35490/CVE-2020-35491)
+* [databind#2996]: Block 2 more gadget types (newrelic-agent, CVE-2020-36188/CVE-2020-36189)
 
 
 1.9.13 (14-Jul-2013)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -67,6 +67,7 @@ One more patch release for 1.9.
 * [databind#2462]: Block two more gadget types (commons-configuration/-2, CVE-2019-14892)
 * [databind#2469]: Block one more gadget type (xalan2, might be related to CVE-2019-14893)
 * [databind#2704]: Block one more gadget type (xalan2, CVE-2020-14062)
+* [databind#2765]: Block one more gadget type (org.jsecurity, 2020-14195)
 
 1.9.13 (14-Jul-2013)
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -206,6 +206,11 @@ public class SubTypeValidator
         s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource");
         s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource");
 
+        // [databind#2997]: tomcat/naming-factory-dbcp (embedded dbcp 1.x)
+        // (derivative of #2478)
+        s.add("org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource");
+        s.add("org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -109,9 +109,12 @@ public class SubTypeValidator
         // [databind#2704]: xalan2
         s.add("com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool");
 
-        // [databind#2478]: comons-dbcp, p6spy
+        // [databind#2478]: commons-dbcp 1.x, p6spy
+        // [databind#3004]: commons-dbcp 1.x
+        s.add("org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS");
         s.add("org.apache.commons.dbcp.datasources.PerUserPoolDataSource");
         s.add("org.apache.commons.dbcp.datasources.SharedPoolDataSource");
+
         s.add("com.p6spy.engine.spy.P6DataSource");
         // [databind#2498]: log4j-extras (1.2)
         s.add("org.apache.log4j.receivers.db.DriverManagerConnectionSource");
@@ -175,8 +178,9 @@ public class SubTypeValidator
         // [databind#2682]: commons-jelly
         s.add("org.apache.commons.jelly.impl.Embedded");
 
-        // [databind#2688]: apache/drill
+        // [databind#2688], [databind#3004]: apache/drill
         s.add("oadd.org.apache.xalan.lib.sql.JNDIConnectionPool");
+        s.add("oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS");
         s.add("oadd.org.apache.commons.dbcp.datasources.PerUserPoolDataSource");
         s.add("oadd.org.apache.commons.dbcp.datasources.SharedPoolDataSource");
 
@@ -199,22 +203,25 @@ public class SubTypeValidator
         s.add("com.nqadmin.rowset.JdbcRowSetImpl");
         s.add("org.arrah.framework.rdbms.UpdatableJdbcRowsetImpl");
 
-        // [databind#2986]: dbcp2
+        // [databind#2986], [databind#3004]: dbcp2
         s.add("org.apache.commons.dbcp2.datasources.PerUserPoolDataSource");
         s.add("org.apache.commons.dbcp2.datasources.SharedPoolDataSource");
+        s.add("org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS");
 
         // [databind#2996]: newrelic-agent + embedded-logback-core
         // (derivative of #2334 and #2389)
         s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource");
         s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource");
 
-        // [databind#2997]: tomcat/naming-factory-dbcp (embedded dbcp 1.x)
+        // [databind#2997]/[databind#3004]: tomcat/naming-factory-dbcp (embedded dbcp 1.x)
         // (derivative of #2478)
+        s.add("org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS");
         s.add("org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource");
         s.add("org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource");
 
-        // [databind#2998]: org.apache.tomcat/tomcat-dbcp (embedded dbcp 2.x)
+        // [databind#2998]/[databind#3004]: org.apache.tomcat/tomcat-dbcp (embedded dbcp 2.x)
         // (derivative of #2478)
+        s.add("org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS");
         s.add("org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource");
         s.add("org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource");
 
@@ -222,9 +229,9 @@ public class SubTypeValidator
         // (derivative of #2469)
         s.add("com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnectionPool");
 
-        // [databind#303]: another case of embedded Xalan (derivative of #2469)
+        // [databind#3003]: another case of embedded Xalan (derivative of #2469)
         s.add("org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool");
-
+        
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -197,6 +197,10 @@ public class SubTypeValidator
         s.add("com.nqadmin.rowset.JdbcRowSetImpl");
         s.add("org.arrah.framework.rdbms.UpdatableJdbcRowsetImpl");
 
+        // [databind#2986]: dbcp2
+        s.add("org.apache.commons.dbcp2.datasources.PerUserPoolDataSource");
+        s.add("org.apache.commons.dbcp2.datasources.SharedPoolDataSource");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -187,6 +187,9 @@ public class SubTypeValidator
         // [databind#2764]: org.jsecurity:
         s.add("org.jsecurity.realm.jndi.JndiRealmFactory");
 
+        // [databind#2798]: com.pastdev.httpcomponents:
+        s.add("com.pastdev.httpcomponents.configuration.JndiConfiguration");
+        
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -222,6 +222,9 @@ public class SubTypeValidator
         // (derivative of #2469)
         s.add("com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnectionPool");
 
+        // [databind#303]: another case of embedded Xalan (derivative of #2469)
+        s.add("org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -133,8 +133,9 @@ public class SubTypeValidator
         // [databind#2814]: anteros-dbcp
         s.add("br.com.anteros.dbcp.AnterosDBCPDataSource");
 
-        // [databind#2642]: javax.swing (jdk)
+        // [databind#2642][databind#2854]: javax.swing (jdk)
         s.add("javax.swing.JEditorPane");
+        s.add("javax.swing.JTextPane");
 
         // [databind#2648], [databind#2653]: shire-core
         s.add("org.apache.shiro.realm.jndi.JndiRealmFactory");

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -177,6 +177,8 @@ public class SubTypeValidator
 
         // [databind#2688]: apache/drill
         s.add("oadd.org.apache.xalan.lib.sql.JNDIConnectionPool");
+        s.add("oadd.org.apache.commons.dbcp.datasources.PerUserPoolDataSource");
+        s.add("oadd.org.apache.commons.dbcp.datasources.SharedPoolDataSource");
 
         // [databind#2698]: weblogic w/ oracle/aq-jms
         // (note: dependency not available via Maven Central, but as part of

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -127,9 +127,11 @@ public class SubTypeValidator
         // [databind#2631]: shaded hikari-config
         s.add("org.apache.hadoop.shaded.com.zaxxer.hikari.HikariConfig");
 
-        // [databind#2634]: ibatis-sqlmap, anteros-core
+        // [databind#2634]: ibatis-sqlmap, anteros-core/-dbcp
         s.add("com.ibatis.sqlmap.engine.transaction.jta.JtaTransactionConfig");
         s.add("br.com.anteros.dbcp.AnterosDBCPConfig");
+        // [databind#2814]: anteros-dbcp
+        s.add("br.com.anteros.dbcp.AnterosDBCPDataSource");
 
         // [databind#2642]: javax.swing (jdk)
         s.add("javax.swing.JEditorPane");

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -216,6 +216,10 @@ public class SubTypeValidator
         s.add("org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource");
         s.add("org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource");
 
+        // [databind#2999]: org.glassfish.web/javax.servlet.jsp.jstl (embedded Xalan)
+        // (derivative of #2469)
+        s.add("com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnectionPool");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -201,6 +201,11 @@ public class SubTypeValidator
         s.add("org.apache.commons.dbcp2.datasources.PerUserPoolDataSource");
         s.add("org.apache.commons.dbcp2.datasources.SharedPoolDataSource");
 
+        // [databind#2996]: newrelic-agent + embedded-logback-core
+        // (derivative of #2334 and #2389)
+        s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource");
+        s.add("com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -184,6 +184,9 @@ public class SubTypeValidator
         s.add("oracle.jms.AQjmsXAQueueConnectionFactory");
         s.add("oracle.jms.AQjmsXAConnectionFactory");
 
+        // [databind#2764]: org.jsecurity:
+        s.add("org.jsecurity.realm.jndi.JndiRealmFactory");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -191,7 +191,11 @@ public class SubTypeValidator
 
         // [databind#2798]: com.pastdev.httpcomponents:
         s.add("com.pastdev.httpcomponents.configuration.JndiConfiguration");
-        
+
+        // [databind#2826], [databind#2827]
+        s.add("com.nqadmin.rowset.JdbcRowSetImpl");
+        s.add("org.arrah.framework.rdbms.UpdatableJdbcRowsetImpl");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
+++ b/src/mapper/java/org/codehaus/jackson/map/jsontype/impl/SubTypeValidator.java
@@ -211,6 +211,11 @@ public class SubTypeValidator
         s.add("org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource");
         s.add("org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource");
 
+        // [databind#2998]: org.apache.tomcat/tomcat-dbcp (embedded dbcp 2.x)
+        // (derivative of #2478)
+        s.add("org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource");
+        s.add("org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource");
+
         DEFAULT_NO_DESER_CLASS_NAMES = Collections.unmodifiableSet(s);
     }
 


### PR DESCRIPTION
backport security fixes applied to SubTypeValidator since last backporting https://github.com/atlassian/jackson-1/pull/4
our patched fork should contain all veracode reported vulnerabilities, see https://hello.atlassian.net/wiki/spaces/SERVER/pages/1094531756/Jackson+1+vulnerabilities+backport